### PR TITLE
Expose component for direct import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,14 @@
-import { App, Plugin } from "vue"
-import PinInputVue from "./components/PinInput.vue"
+import { App, Plugin } from "vue";
+import PinInputVue from "./components/PinInput.vue";
 
-export type { Cell, CellInputType, CellsInputTypes } from './types/types'
+export type { Cell, CellInputType, CellsInputTypes } from "./types/types";
 
-const PinInput: Plugin = {
+export const PinInput = PinInputVue;
+
+const PinInputPlugin: Plugin = {
   install: (app: App, options = {}): void => {
-    app.component("pin-input", PinInputVue)
-  }
-}
+    app.component("pin-input", PinInputVue);
+  },
+};
 
-export default PinInput
+export default PinInputPlugin;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
-import { createApp } from 'vue'
-import App from './example/App.vue'
+import { createApp } from "vue";
+import App from "./example/App.vue";
+import PinInputPlugin from "./index";
 
-import PinInput from './index'
-createApp(App).use(PinInput).mount('#app')
+createApp(App).use(PinInputPlugin).mount("#app");


### PR DESCRIPTION
With this PR, consumers are now able to import the component from the path, instead of adding the plugin globally.